### PR TITLE
Responsive display

### DIFF
--- a/src/components/QuestionBox/QuestionBox.tsx
+++ b/src/components/QuestionBox/QuestionBox.tsx
@@ -2,6 +2,7 @@ import { View, Text } from 'react-native';
 import React from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { questionBoxStyles } from './style';
+import { getDisplayHeight, getDisplayWidth } from '../../utility';
 interface Props {
   payload: string;
 }
@@ -10,16 +11,26 @@ export default function QuestionBox(props: Props) {
   const { payload } = props;
   return (
     <TouchableOpacity>
-      <View style={questionBoxStyles.container}>
+      <View
+        style={{
+          ...questionBoxStyles.container,
+        }}
+      >
         <View
           style={{
             backgroundColor: 'gray',
-            width: 73,
-            height: 73,
-            marginRight: 16,
+            width: getDisplayWidth(73),
+            height: getDisplayHeight(73),
           }}
         ></View>
-        <Text style={questionBoxStyles.font}>{payload}</Text>
+        <Text
+          style={{
+            marginLeft: getDisplayWidth(16),
+            ...questionBoxStyles.font,
+          }}
+        >
+          {payload}
+        </Text>
       </View>
     </TouchableOpacity>
   );

--- a/src/components/QuestionBox/style.js
+++ b/src/components/QuestionBox/style.js
@@ -1,17 +1,26 @@
 import { StyleSheet } from 'react-native';
-import { mediumFontSize, shadow, boldFontWeight } from '../../style/share';
+import {
+  mediumFontSize,
+  shadow,
+  boldFontWeight,
+  bgColor,
+} from '../../style/share';
+import { getDisplayHeight, getDisplayWidth } from '../../utility';
+
 export const questionBoxStyles = StyleSheet.create({
   container: {
-    width: 380,
-    height: 135,
-    padding: 9,
-    borderRadius: 26,
+    width: getDisplayWidth(380),
+    height: getDisplayHeight(135),
+    backgroundColor: bgColor,
+    padding: getDisplayWidth(9),
+    borderRadius: getDisplayWidth(26),
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'space-around',
     ...shadow,
   },
   font: {
+    width: getDisplayWidth(280),
     fontWeight: boldFontWeight,
     fontSize: mediumFontSize,
   },

--- a/src/constants/displayInfo.ts
+++ b/src/constants/displayInfo.ts
@@ -1,0 +1,7 @@
+import { Dimensions } from 'react-native';
+
+export const WINDOW_WIDTH = Dimensions.get('window').width;
+export const WINDOW_HEIGHT = Dimensions.get('window').height;
+
+export const FIGMA_WIDTH = 428;
+export const FIGMA_HEIGHT = 926;

--- a/src/style/share.ts
+++ b/src/style/share.ts
@@ -1,4 +1,6 @@
 export const baseColor = '#FFF7DA';
+export const bgColor = '#fff';
+
 export const mediumFontWeight = '400';
 export const boldFontWeight = '700';
 export const mediumFontSize = 30;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,0 +1,16 @@
+import {
+  FIGMA_HEIGHT,
+  FIGMA_WIDTH,
+  WINDOW_HEIGHT,
+  WINDOW_WIDTH,
+} from './constants/displayInfo';
+
+export function getDisplayWidth(width: number) {
+  const newWidth = (WINDOW_WIDTH / FIGMA_WIDTH) * width;
+  return newWidth;
+}
+
+export function getDisplayHeight(height: number) {
+  const newHeight = (WINDOW_HEIGHT / FIGMA_HEIGHT) * height;
+  return newHeight;
+}


### PR DESCRIPTION
`utility.ts`에 figma 디자인 기준으로 너비, 높이값을 넣으면 디스플레이 기준으로 너비를 바꿔주는 
`getDisplayWidth`와 `getDisplayHeight`가 추가되었습니다. 앞으로 CSS 할 때는 위 함수를 이용하여 넣어주면 됩니다.

활용 예시는 QuestionBox를 참조하시면 됩니다.

궁금하거나 고칠 부분이 있다면 알려주십쇼